### PR TITLE
Use a click event instead of touchstart event

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -116,7 +116,7 @@
   <script>
     hljs.initHighlightingOnLoad();
     $(function() {
-      $('.hiring-banner').bind("touchstart", function() {
+      $('.hiring-banner').bind("click", function() {
         location.href = '/jobs.html';
       });
     });


### PR DESCRIPTION
touchstart로 이벤트를 받으면 해당 영역부터 터치하면서 드래그를 시작할 때 의도와는 다르게 드래그 도중에 자동으로 전환이 일어나게 되어서 불편합니다.