### PR TITLE
설치시 pygments.rb도 같이 받도록 수정

### DIFF
--- a/install-mac.sh
+++ b/install-mac.sh
@@ -2,4 +2,5 @@
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install ruby
 sudo gem install github-pages
+sudo gem install pygments.rb
 echo "You can run the server by using 'jekyll serve'."


### PR DESCRIPTION
이게 없으면 설치시 다음과 같은 문제가 발생합니다.
```
  Dependency Error: Yikes! It looks like you don't have pygments or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- pygments' If you run into trouble, you can find helpful resources at http://jekyllrb.com/help/!
  Liquid Exception: pygments in /Users/chan/Work/spoqa.github.com/_posts/2012-06-18-enhence-web-performance.md
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    pygments
```