### PR TITLE
참조 링크 수정

### DIFF
--- a/_posts/2013-08-21-cte.md
+++ b/_posts/2013-08-21-cte.md
@@ -120,11 +120,11 @@ CTE 부분의 재귀항과 비재귀 항을 union all 해주는 subdepartment를
 ----
 원문: [CTEReadme][1]
 
-참조:  [공통 테이블 식 사용](http://msdn.microsoft.com/ko-kr/library/ms190766) ,[공통 테이블 식을 사용하는 재귀 쿼리](http://msdn.microsoft.com/ko-kr/library/ms186243)
+참조:  [공통 테이블 식 사용](http://msdn.microsoft.com/ko-kr/library/ms190766), [공통 테이블 식을 사용하는 재귀 쿼리](http://msdn.microsoft.com/ko-kr/library/ms186243)
 
-[1]:(http://wiki.postgresql.org/wiki/CTEReadme)
-[2]:(http://www.postgresql.org/)
-[3]:(http://www.sqlalchemy.org/)
-[4]:(http://docs.sqlalchemy.org/en/rel_0_8/core/)
-[5]:(http://en.wikipedia.org/wiki/Common_table_expression#Common_table_expression)
+[1]:http://wiki.postgresql.org/wiki/CTEReadme
+[2]:http://www.postgresql.org/
+[3]:http://www.sqlalchemy.org/
+[4]:http://docs.sqlalchemy.org/en/rel_0_8/core/
+[5]:http://en.wikipedia.org/wiki/Common_table_expression#Common_table_expression
 


### PR DESCRIPTION
Fixes #135.

참조 문법 오류로 모든 링크에 괄호가 잘못 붙어 깨져 있는 문제를 수정하고, 또 추가로 쉼표 위치를 하나 옮겼습니다.