### PR TITLE
웹 폰트 관련 코드와 GA 관련 코드를 분리

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,6 +62,9 @@
         wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js';
         s.parentNode.insertBefore(wf, s);
     })(document);
+  </script>
+
+  <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
해당 부분 코드를 참조하는 과정에서 GA코드까지 복사해가는 사례가 늘어 `<script>` 태그 차원에서 분리합니다.